### PR TITLE
Add wrapper for create-react-class

### DIFF
--- a/src/reacl_c/impl/create-react-class-wrapper.js
+++ b/src/reacl_c/impl/create-react-class-wrapper.js
@@ -1,0 +1,4 @@
+import createReactClassModuleFunction from 'create-react-class'
+
+export const createReactClass = createReactClassModuleFunction
+

--- a/src/reacl_c/impl/react0.cljs
+++ b/src/reacl_c/impl/react0.cljs
@@ -1,5 +1,5 @@
 (ns ^:no-doc reacl-c.impl.react0
-  (:require ["create-react-class" :as createReactClass]
+  (:require ["./create-react-class-wrapper.js" :refer [createReactClass]]
             ["react" :as react]
             #_["react-dom/client" :as react-dom]
             ["react-dom" :as react-dom]


### PR DESCRIPTION
So that CommonJS module function doesn't break the import